### PR TITLE
allow restricting sort to specific keys per type

### DIFF
--- a/lib/PONAPI/Server/config.yml
+++ b/lib/PONAPI/Server/config.yml
@@ -32,7 +32,8 @@ template: "simple"
 # JSONAPI
 
 jsonapi:
-  supports_sort: 0
+  sort:
+    enabled: "false"
 
 ######################################################################
 # PONAPI

--- a/lib/PONAPI/Server/routes/Dancer2/Plugin/JSONAPI/Role/Error.pm
+++ b/lib/PONAPI/Server/routes/Dancer2/Plugin/JSONAPI/Role/Error.pm
@@ -3,7 +3,7 @@ package Dancer2::Plugin::JSONAPI::Role::Error;
 use Moo::Role;
 
 sub jsonapi_error {
-    my ( $dsl, $error, $status ) = @_;
+    my ( $dsl, $status, $error ) = @_;
     $dsl->response->status( $status || 500 );
     $dsl->response->content({
         jsonapi => { version => "1.0" },


### PR DESCRIPTION
this change will allow the following configuration to support sorting specific keys per type:

jsonapi:
  sort:
    enabled: "true"
    allowed_keys:
      articles: [ 'title', 'created' ]
      people: [ 'name' ]
