### PR TITLE
Added PONAPI::Server

### DIFF
--- a/lib/PONAPI/Server.pm
+++ b/lib/PONAPI/Server.pm
@@ -1,0 +1,24 @@
+package PONAPI::Server;
+
+use strict;
+use warnings;
+use File::Spec;
+my $routes;
+BEGIN {
+    my $ponapi_server = (caller(0))[1];
+    my ($vol, $dir, $file) = File::Spec->splitpath($ponapi_server);
+    my $server_dir = File::Spec->catpath($vol, $dir);
+
+    $routes = File::Spec->catdir($server_dir, 'Server', 'routes');
+}
+
+use if $routes, lib => $routes;
+
+use PONAPI;
+
+BEGIN {
+    *PONAPI::Server:: = \*PONAPI::;
+}
+
+1;
+


### PR DESCRIPTION
This is simply a convenience for applications; we've set up the
server itself in lib/PONAPI/Server/, which means we need
lib/PONAPI/Server/routes/ in @INC for perl to find the files;
Loading PONAPI::Server does exactly that, then loads PONAPI.pm,
and sets PONAPI::Server as an alias to PONAPI.
