### PR TITLE
less use of 'does' for better performance

### DIFF
--- a/Server/lib/PONAPI/DAO/Request.pm
+++ b/Server/lib/PONAPI/DAO/Request.pm
@@ -59,6 +59,50 @@ sub BUILDARGS {
     return \%args;
 }
 
+# These validation methods will be overwritten in the appropriate roles.
+# They cover the case where an attribute is NOT expected.
+sub _validate_id {
+    my ( $self, $args ) = @_;
+    return unless defined $args->{id};
+    $self->_bad_request( "`id` is not allowed for this request" )
+}
+
+sub _validate_rel_type {
+    my ( $self, $args ) = @_;
+    return unless defined $args->{rel_type};
+    $self->_bad_request( "`relationship type` is not allowed for this request" );
+}
+
+sub _validate_include {
+    my ( $self, $args ) = @_;
+    return unless defined $args->{include};
+    $self->_bad_request( "`include` is not allowed for this request" );
+}
+
+sub _validate_fields {
+    my ( $self, $args ) = @_;
+    return unless defined $args->{fields};
+    $self->_bad_request( "`fields` is not allowed for this request" );
+}
+
+sub _validate_filter {
+    my ( $self, $args ) = @_;
+    return unless defined $args->{filter};
+    $self->_bad_request( "`filter` is not allowed for this request" );
+}
+
+sub _validate_sort {
+    my ( $self, $args ) = @_;
+    return unless defined $args->{sort};
+    $self->_bad_request( "`sort` is not allowed for this request" );
+}
+
+sub _validate_page {
+    my ( $self, $args ) = @_;
+    return unless defined $args->{page};
+    $self->_bad_request( "`page` is not allowed for this request" );
+}
+
 sub BUILD {
     my ( $self, $args ) = @_;
 
@@ -67,59 +111,13 @@ sub BUILD {
     return $self->_bad_request( "Type `$type` doesn't exist.", 404 )
         unless $self->repository->has_type( $type );
 
-    # validate `id` parameter
-    if ( $self->does('PONAPI::DAO::Request::Role::HasID') ) {
-        $self->_bad_request( "`id` is missing for this request" )
-            unless $self->has_id;
-    }
-    elsif ( defined $args->{id} ) {
-        $self->_bad_request( "`id` is not allowed for this request" );
-    }
-
-    # validate `rel_type` parameter
-    if ( $self->does('PONAPI::DAO::Request::Role::HasRelationshipType') ) {
-        defined $args->{rel_type}
-            ? $self->_validate_rel_type
-            : $self->_bad_request( "`relationship type` is missing for this request" );
-    }
-    elsif ( defined $args->{rel_type} ) {
-        $self->_bad_request( "`relationship type` is not allowed for this request" );
-    }
-
-    # validate `include` parameter
-    if ( defined $args->{include} ) {
-        $self->does('PONAPI::DAO::Request::Role::HasInclude')
-            ? $self->_validate_include
-            : $self->_bad_request( "`include` is not allowed for this request" );
-    }
-
-    # validate `fields` parameter
-    if ( defined $args->{fields} ) {
-        $self->does('PONAPI::DAO::Request::Role::HasFields')
-            ? $self->_validate_fields
-            : $self->_bad_request( "`fields` is not allowed for this request" );
-    }
-
-    # validate `filter` parameter
-    if ( defined $args->{filter} ) {
-        $self->does('PONAPI::DAO::Request::Role::HasFilter')
-            ? $self->_validate_filter
-            : $self->_bad_request( "`filter` is not allowed for this request" );
-    }
-
-    # validate `sort` parameter
-    if ( defined $args->{sort} ) {
-        $self->does('PONAPI::DAO::Request::Role::HasSort')
-            ? $self->_validate_sort
-            : $self->_bad_request( "`sort` is not allowed for this request" );
-    }
-
-    # validate `page` parameter
-    if ( defined $args->{page} ) {
-        $self->does('PONAPI::DAO::Request::Role::HasPage')
-            ? $self->_validate_page
-            : $self->_bad_request( "`page` is not allowed for this request" );
-    }
+    $self->_validate_id($args);
+    $self->_validate_rel_type($args);
+    $self->_validate_include($args);
+    $self->_validate_fields($args);
+    $self->_validate_filter($args);
+    $self->_validate_sort($args);
+    $self->_validate_page($args);
 
     # validate `data`
     if ( exists $args->{data} ) {

--- a/Server/lib/PONAPI/DAO/Request/CreateRelationships.pm
+++ b/Server/lib/PONAPI/DAO/Request/CreateRelationships.pm
@@ -26,15 +26,19 @@ sub execute {
 }
 
 sub _validate_rel_type {
-    my $self     = shift;
+    my ( $self, $args ) = @_;
+
+    return $self->_bad_request( "`relationship type` is missing for this request" )
+        unless $self->has_rel_type;
+
     my $type     = $self->type;
     my $rel_type = $self->rel_type;
 
-    super(@_);
+    return $self->_bad_request( "Types `$type` and `$rel_type` are not related", 404 )
+        unless $self->repository->has_relationship( $type, $rel_type );
 
-    if ( !$self->repository->has_one_to_many_relationship( $type, $rel_type ) ) {
-        $self->_bad_request( "Types `$type` and `$rel_type` are one-to-one" );
-    }
+    return $self->_bad_request( "Types `$type` and `$rel_type` are one-to-one" )
+        unless $self->repository->has_one_to_many_relationship( $type, $rel_type );
 }
 
 

--- a/Server/lib/PONAPI/DAO/Request/DeleteRelationships.pm
+++ b/Server/lib/PONAPI/DAO/Request/DeleteRelationships.pm
@@ -27,15 +27,19 @@ sub execute {
 }
 
 sub _validate_rel_type {
-    my $self     = shift;
+    my ( $self, $args ) = @_;
+
+    return $self->_bad_request( "`relationship type` is missing for this request" )
+        unless $self->has_rel_type;
+
     my $type     = $self->type;
     my $rel_type = $self->rel_type;
 
-    super(@_);
+    return $self->_bad_request( "Types `$type` and `$rel_type` are not related", 404 )
+        unless $self->repository->has_relationship( $type, $rel_type );
 
-    if ( !$self->repository->has_one_to_many_relationship( $type, $rel_type ) ) {
-        $self->_bad_request( "Types `$type` and `$rel_type` are one-to-one" );
-    }
+    return $self->_bad_request( "Types `$type` and `$rel_type` are one-to-one" )
+        unless $self->repository->has_one_to_many_relationship( $type, $rel_type );
 }
 
 

--- a/Server/lib/PONAPI/DAO/Request/Role/HasFields.pm
+++ b/Server/lib/PONAPI/DAO/Request/Role/HasFields.pm
@@ -14,7 +14,9 @@ has fields => (
 );
 
 sub _validate_fields {
-    my $self = shift;
+    my ( $self, $args ) = @_;
+
+    return unless defined $args->{fields};
     return unless $self->has_fields;
 
     my $fields = $self->fields;

--- a/Server/lib/PONAPI/DAO/Request/Role/HasFilter.pm
+++ b/Server/lib/PONAPI/DAO/Request/Role/HasFilter.pm
@@ -14,7 +14,9 @@ has filter => (
 );
 
 sub _validate_filter {
-    my $self = shift;
+    my ( $self, $args ) = @_;
+
+    return unless defined $args->{filter};
 
     $self->has_filter
         or $self->_bad_request( "`filter` is missing values" );

--- a/Server/lib/PONAPI/DAO/Request/Role/HasID.pm
+++ b/Server/lib/PONAPI/DAO/Request/Role/HasID.pm
@@ -9,6 +9,13 @@ has id => (
     predicate => 'has_id',
 );
 
+sub _validate_id {
+    my $self = shift;
+
+    $self->_bad_request( "`id` is missing for this request" )
+        unless $self->has_id;
+}
+
 no Moose::Role; 1;
 
 __END__

--- a/Server/lib/PONAPI/DAO/Request/Role/HasInclude.pm
+++ b/Server/lib/PONAPI/DAO/Request/Role/HasInclude.pm
@@ -14,11 +14,14 @@ has include => (
 );
 
 sub _validate_include {
-    my $self = shift;
-    my $type = $self->type;
+    my ( $self, $args ) = @_;
+
+    return unless defined $args->{include};
 
     return $self->_bad_request( "`include` is missing values" )
         unless $self->has_include >= 1;
+
+    my $type = $self->type;
 
     for ( @{ $self->include } ) {
         $self->repository->has_relationship( $type, $_ )

--- a/Server/lib/PONAPI/DAO/Request/Role/HasPage.pm
+++ b/Server/lib/PONAPI/DAO/Request/Role/HasPage.pm
@@ -13,7 +13,9 @@ has page => (
 );
 
 sub _validate_page {
-    my $self = shift;
+    my ( $self, $args ) = @_;
+
+    return unless defined $args->{page};
 
     $self->has_page
         or $self->_bad_request( "`page` is missing values" );

--- a/Server/lib/PONAPI/DAO/Request/Role/HasRelationshipType.pm
+++ b/Server/lib/PONAPI/DAO/Request/Role/HasRelationshipType.pm
@@ -10,9 +10,9 @@ has rel_type => (
 );
 
 sub _validate_rel_type {
-    my $self = shift;
+    my ( $self, $args ) = @_;
 
-    return $self->_bad_request( "`relationship type` is missing" )
+    return $self->_bad_request( "`relationship type` is missing for this request" )
         unless $self->has_rel_type;
 
     my $type     = $self->type;

--- a/Server/lib/PONAPI/DAO/Request/Role/HasSort.pm
+++ b/Server/lib/PONAPI/DAO/Request/Role/HasSort.pm
@@ -14,7 +14,9 @@ has sort => (
 );
 
 sub _validate_sort {
-    my $self = shift;
+    my ( $self, $args ) = @_;
+
+    return unless defined $args->{sort};
 
     $self->has_sort
         or $self->_bad_request( "`sort` is missing values" );


### PR DESCRIPTION
Profiling on 100k requests (single core in event loop) shows about 10+% improvement with this change which saves many of the `->does` calls.
