### PR TITLE
Correct builder method name for constructing user agent

### DIFF
--- a/Client/lib/PONAPI/Client.pm
+++ b/Client/lib/PONAPI/Client.pm
@@ -119,7 +119,7 @@ sub delete_relationships {
 
 ### private methods
 
-sub build_hijk_ua {
+sub _build_hijk_ua {
     require PONAPI::Client::UA::Hijk;
     return PONAPI::Client::UA::Hijk->new();
 }


### PR DESCRIPTION
We've been playing around with {json:api} and PONAPI at $work and found that the builder method in the client is incorrectly named. 

It's a simple change so I haven't added any further tests or any other changes. Let me know if you'd like to see anything else included.
