### PR TITLE
Correctly read respond_to_updates_with_200 configuration

### DIFF
--- a/Server/lib/PONAPI/Server/ConfigReader.pm
+++ b/Server/lib/PONAPI/Server/ConfigReader.pm
@@ -43,6 +43,7 @@ sub read_config {
     $self->_set_server_self_link;
     $self->_set_server_relative_links;
     $self->_set_repository;
+    $self->_set_server_respond_to_updates_status;
 
     $self->{'ponapi.mediatype'} = 'application/vnd.api+json';
 
@@ -52,8 +53,13 @@ sub read_config {
 sub _set_server_respond_to_updates_status {
     my $self = shift;
 
+    my $server_update = $self->config->{server}{respond_to_updates_with_200};
+
     $self->{'ponapi.respond_to_updates_with_200'} =
-        $self->config->{server}{respond_to_updates_with_200};
+        ( grep { $server_update eq $_ } qw< yes true 1 > ) ? 1 :
+        ( grep { $server_update eq $_ } qw< no false 0 > ) ? 0 :
+        die "[PONAPI Server] server respond_to_updates_with_200 is misconfigured";
+
 }
 
 sub _set_server_sorting {


### PR DESCRIPTION
Hi Again,

We're still trying this out at $work and wanted to include the updated entities in the response of PATCH requests. It looked like this should work by setting the configuration key `respond_to_updates_with_200` but this did not work.

After investigation, the following adds support for it and treats the value the same way as other similar bits of the config.

Cheers