### PR TITLE
JSON::Schema is required by xt/000-schema-validation.t

### DIFF
--- a/Server/dist.ini
+++ b/Server/dist.ini
@@ -21,7 +21,6 @@ skip = ^Path::Class::*
 skip = ^PONAPI::Client
 skip = ^Test::Builder::ButReallyLaxAboutFailing
 skip = ^URI::*
-skip = JSON::Schema
 skip = Exporter
 skip = File::Temp
 skip = HTTP::Tiny
@@ -40,6 +39,7 @@ Plack = 1.0029
 Test::Simple = 0.98
 DBD::SQLite = 1.48
 Plack::Middleware::MethodOverride = 0.15
+JSON::Schema = 0.016
 
 [MetaProvides::Package]
 meta_noindex = 1


### PR DESCRIPTION
I noticed the package JSON::Schema isn't detected missing.
Probably because it is used in xt tests.
I used the current topmost version available in CPAN.

Signed-off-by: Mikko Johannes Koivunalho <mikko.koivunalho@inoviagroup.se>