### PR TITLE
Fix issue with sometimes failing test t/030-Server/001-errors.t

### DIFF
--- a/Server/lib/PONAPI/Server.pm
+++ b/Server/lib/PONAPI/Server.pm
@@ -239,7 +239,7 @@ sub _ponapi_query_params {
     my $unesacpe_values = !!$req->headers->header('X-PONAPI-Escaped-Values');
 
     # loop over query parameters (unique keys)
-    for my $k ( keys %{ $query_params } ) {
+    for my $k ( sort keys %{ $query_params } ) {
         my ( $p, $f ) = $k =~ /^ (\w+?) (?:\[(\w+)\])? $/x;
 
         # key not matched

--- a/Server/t/030-Server/001-errors.t
+++ b/Server/t/030-Server/001-errors.t
@@ -143,7 +143,6 @@ subtest '... bad requests (GET)' => sub {
             'fields',
             'fields=',
             'include',
-            'include=&',
             'include=',
             'include[articles]',
             'page=page',
@@ -159,6 +158,20 @@ subtest '... bad requests (GET)' => sub {
             "... bad request $req caught",
         );
     }
+
+    {
+        my $req = 'include=&';
+        my $res = $app->request( GET "/articles/1?$req", %Accept );
+        error_test(
+            $res,
+            {
+                detail => "$BAD_REQUEST_MSG (unsupported parameters)",
+                status => 400,
+            },
+            "... bad request $req caught",
+        );
+    }
+
 };
 
 subtest '... bad requests (POST)' => sub {


### PR DESCRIPTION
Failing test prevented me from installing directly from CPAN.

Because the query parameters are looped over in a random order,
the returned error changes according to which is found first.
In this case one of these:
{JSON:API} Bad request
{JSON:API} Bad request (unsupported parameters)

This change fixes the test so unsupported parameters are tested and
makes the server more predictable.

Signed-off-by: Mikko Johannes Koivunalho <mikko.koivunalho@inoviagroup.se>