### PR TITLE
Fix wrong Moose role name

### DIFF
--- a/Server/xt/001-server-with-client.t
+++ b/Server/xt/001-server-with-client.t
@@ -479,7 +479,7 @@ BEGIN {
 
         use Moose;
 
-        with 'PONAPI::Builder::Role::HasPagination';
+        with 'PONAPI::Document::Builder::Role::HasPagination';
 
         has port => (
             is => 'ro',


### PR DESCRIPTION
Error when tested:

PONAPI/Server $ PERL5LIB="${PERL5LIB}:$(pwd)/../Tools/lib" prove -lv xt/001-server-with-client.t
xt/001-server-with-client.t .. You can only consume roles, PONAPI::Builder::Role::HasPagination is not a Moose role at /home/users/mikkoi/.anyenv/envs/plenv/versions/5.14.2-for-dev/lib/perl5/site_perl/5.14.2/x86_64-linux/Moose/Exporter.pm line 419
        Moose::with('PONAPI::Builder::Role::HasPagination')
        called at xt/001-server-with-client.t line 482
        main::BEGIN at xt/001-server-with-client.t line 690
        eval {...} at xt/001-server-with-client.t line 690
BEGIN failed--compilation aborted at xt/001-server-with-client.t line 690.

Signed-off-by: Mikko Johannes Koivunalho <mikko.koivunalho@inoviagroup.se>