### PR TITLE
Pass ssl_options from the constructor of PONAPI::Client::UA::YAHC to YAHC

### DIFF
--- a/Client/lib/PONAPI/Client/UA/YAHC.pm
+++ b/Client/lib/PONAPI/Client/UA/YAHC.pm
@@ -31,6 +31,11 @@ has scheme => (
     isa => 'Str',
 );
 
+has ssl_options => (
+    is  => 'rw',
+    isa => 'Ref',
+);
+
 ################################################################################
 ################################################################################
 
@@ -62,6 +67,7 @@ sub send_http_request {
 
     local $request->{callback} = $callback;
     local $request->{scheme} = $self->scheme;
+    local $request->{ssl_options} = $self->ssl_options;
 
     my $yahc = $self->yahc;
 


### PR DESCRIPTION
Hash `ssl_options` is required by YAHC to perform SSL connection with custom certificates.