### PR TITLE
Add HTTP Accept header for all JSON API requests

### DIFF
--- a/Client/lib/PONAPI/Client.pm
+++ b/Client/lib/PONAPI/Client.pm
@@ -151,8 +151,8 @@ sub _send_ponapi_request {
     my %args = @_;
 
     my @mt_header = (
-        ( $args{body} ? 'Content-Type' : 'Accept' ),
-        'application/vnd.api+json'
+        ( $args{body} ? ( 'Content-Type', 'application/vnd.api+json' ) : () ),
+        'Accept', 'application/vnd.api+json'
     );
 
     my ($status, $content, $failed, $e);


### PR DESCRIPTION
Setting HTTP Accept header for all JSON API requests to explicitly instruct the server that the client is expecting JSON API response.

Fixes #91.